### PR TITLE
Bugfix: Error when fetching package dependencies

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,9 @@
 name: store_redirect_example
 description: Demonstrates how to use the store_redirect plugin.
 
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
## What's changed?

Updated the pubspec.yaml file in the `example/` folder to fix the following error when running `flutter pub get`:

```bash
pubspec.yaml has no lower-bound SDK constraint.
You should edit pubspec.yaml to contain an SDK constraint:

environment:
  sdk: '>=2.10.0 <3.0.0'

See https://dart.dev/go/sdk-constraint
Running "flutter pub get" in example...
pub get failed (65; See https://dart.dev/go/sdk-constraint)
```