### PR TITLE
Feature: Add simple unit test and fix RaisedButton deprecation warning

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,15 +17,20 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return new MaterialApp(
-        home: new Scaffold(
-            appBar: new AppBar(title: new Text('Launch App Redirect')),
-            body: new Center(
-                child: new RaisedButton(
-                    child: new Text("Redirect App"),
-                    onPressed: () {
-                      StoreRedirect.redirect(
-                          androidAppId: "com.iyaffle.rangoli",
-                          iOSAppId: "585027354");
-                    }))));
+      home: new Scaffold(
+        appBar: new AppBar(title: new Text('Launch App Redirect')),
+        body: new Center(
+          child: new ElevatedButton(
+            child: new Text("Redirect App"),
+            onPressed: () {
+              StoreRedirect.redirect(
+                androidAppId: "com.iyaffle.rangoli",
+                iOSAppId: "585027354",
+              );
+            },
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -4,4 +4,18 @@
 // find child widgets in the widget tree, read text, and verify that the values of widget properties
 // are correct.
 
-void main() {}
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:store_redirect_example/main.dart';
+
+void main() {
+  testWidgets("Locates the store redirect button", (WidgetTester tester) async {
+    await tester.pumpWidget(MyApp());
+
+    final buttonFinder = find.byType(ElevatedButton);
+    final buttonTextFinder = find.text("Redirect App");
+
+    expect(buttonFinder, findsOneWidget);
+    expect(buttonTextFinder, findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What's changed?

test: Add simple unit test to locate the store redirect button in the example app
fix: RaisedButton deprecation warning